### PR TITLE
feat: retrieve live channels m3u URL from github

### DIFF
--- a/live_channel_m3u_url.txt
+++ b/live_channel_m3u_url.txt
@@ -1,0 +1,1 @@
+https://live3-mediaset-it.akamaized.net/content/hls_clr_xo/live/channel(ch{ch})/index.m3u8

--- a/resources/lib/mediaset.py
+++ b/resources/lib/mediaset.py
@@ -1,6 +1,7 @@
 from phate89lib import rutils
 import re
 import math
+import urllib2
 
 class Mediaset(rutils.RUtils):
 
@@ -100,8 +101,9 @@ class Mediaset(rutils.RUtils):
 
     def get_canali_live(self):
         self.log('Getting the list of live channels', 4)
-        
-        url = "https://live1-mediaset-it.akamaized.net/content/hls_clr_xo/live/channel(ch{ch})/index.m3u8"
+
+        for line in urllib2.urlopen("https://raw.githubusercontent.com/phate89/plugin.video.videomediaset/master/live_channel_m3u_url.txt")
+            url = line
 
         arrdata = []
 


### PR DESCRIPTION
This change should make it easier to update the live channels URL, since it seems to change quite often.

Now the plugin will download the m3u8 URL from a file located in this GitHub repository, so that a single PR will be enough to update/fix all the clients.

I'm not quite good at Python so please double check it.